### PR TITLE
JSONAssert added to fix flaky tets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <cs.junit.dataprovider.version>1.13.1</cs.junit.dataprovider.version>
         <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
         <cs.mockito.version>3.2.4</cs.mockito.version>
+        <cs.skyscreamer.version>1.5.0</cs.skyscreamer.version>
         <cs.powermock.version>2.0.5</cs.powermock.version>
         <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
         <cs.selenium-java-client-driver.version>1.0.1</cs.selenium-java-client-driver.version>
@@ -715,6 +716,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${cs.skyscreamer.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+
         <dependency>
             <groupId>com.tngtech.java</groupId>
             <artifactId>junit-dataprovider</artifactId>
@@ -772,6 +782,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                 <!-- Other configurations -->
+                         <failOnViolation>true</failOnViolation>
+                </configuration>
                 <executions>
                     <execution>
                         <id>cloudstack-checkstyle</id>

--- a/server/src/test/java/com/cloud/server/StatsCollectorTest.java
+++ b/server/src/test/java/com/cloud/server/StatsCollectorTest.java
@@ -35,6 +35,7 @@ import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.BatchPoints.Builder;
 import org.influxdb.dto.Point;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +48,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.cloud.agent.api.VmDiskStatsEntry;
 import com.cloud.agent.api.VmStatsEntry;
@@ -300,7 +302,12 @@ public class StatsCollectorTest {
         VmStatsVO actual = vmStatsVOCaptor.getAllValues().get(0);
         Assert.assertEquals(Long.valueOf(2L), actual.getVmId());
         Assert.assertEquals(Long.valueOf(1L), actual.getMgmtServerId());
-        Assert.assertEquals(expectedVmStatsStr, actual.getVmStatsData());
+        try {
+            JSONAssert.assertEquals(expectedVmStatsStr, actual.getVmStatsData(), true);
+        } catch (JSONException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
         Assert.assertEquals(timestamp, actual.getTimestamp());
     }
 


### PR DESCRIPTION
## What is the purpose of this PR
This PR fixes the flaky test persistVirtualMachineStatsTestPersistsSuccessfully resulting from https://github.com/mahbubsumon085/cloudstack-flaky-test-resolve/blob/main/server/src/test/java/com/cloud/server/StatsCollectorTest.java
The mentioned tests may fail or pass when it is run as Gson's json creation does not guarantee the order of the variable declaration.
## Why the tests fail
The test StatsCollectorTest#persistVirtualMachineStatsTestPersistsSuccessfully fails as the method persistVirtualMachineStats using the toJson() method of Google’s Gson library, in test assuming it will return the JSON string maintaining the variable declaration order, but in reality it does not guarantee the order. Google's Gson library uses Hashmap which does not maintain the order of the json object.
## Reproduce the test failure
Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:
sudo mvn -pl server edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.server.StatsCollectorTest#persistVirtualMachineStatsTestPersistsSuccessfully
## Expected results
The tests should run successfully when run with NonDex.
## Actual Result
We get the following failure for test https://github.com/mahbubsumon085/cloudstack-flaky-test-resolve/blob/main/server/src/test/java/com/cloud/server/StatsCollectorTest #persistVirtualMachineStatsTestPersistsSuccessfully :
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.816 s <<< FAILURE! - in com.cloud.server.StatsCollectorTest
[ERROR] persistVirtualMachineStatsTestPersistsSuccessfully(com.cloud.server.StatsCollectorTest) Time elapsed: 1.807 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[vmId":2,"cpuUtilization":6.0,"networkReadKBs":7.0,"networkWriteKBs":8.0,"diskReadIOs":12.0,"diskWriteIOs":13.0,"diskReadKBs":10.0,"diskWriteKBs":11.0,"memoryKBs":3.0,"intFreeMemoryKBs":4.0,"targetMemoryKBs":5.0,"numCPUs":9,"entityType":"vm"]}> but was:<{"[memoryKBs":3.0,"diskWriteKBs":11.0,"entityType":"vm","diskWriteIOs":13.0,"intFreeMemoryKBs":4.0,"targetMemoryKBs":5.0,"networkWriteKBs":8.0,"diskReadKBs":10.0,"numCPUs":9,"diskReadIOs":12.0,"cpuUtilization":6.0,"vmId":2,"networkReadKBs":7.0]}>
at com.cloud.server.StatsCollectorTest.persistVirtualMachineStatsTestPersistsSuccessfully(StatsCollectorTest.java:303)
## Fix
For the test persistVirtualMachineStatsTestPersistsSuccessfully: Used the JSONAssert library that confirms test passing irrespective of json key order in json string.