### PR TITLE
fixing flaky test with source code change

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -182,6 +182,7 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import com.sun.management.OperatingSystemMXBean;
@@ -2171,7 +2172,8 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 statsForCurrentIteration.getNetworkWriteKBs(), statsForCurrentIteration.getNumCPUs(), statsForCurrentIteration.getDiskReadKBs(),
                 statsForCurrentIteration.getDiskWriteKBs(), statsForCurrentIteration.getDiskReadIOs(), statsForCurrentIteration.getDiskWriteIOs(),
                 statsForCurrentIteration.getEntityType());
-        VmStatsVO vmStatsVO = new VmStatsVO(statsForCurrentIteration.getVmId(), msId, timestamp, gson.toJson(vmStats));
+        Gson gsonInner = new GsonBuilder().registerTypeAdapter(VmStatsEntryBase.class, new VmStatsEntryBaseJsonSerializer()).create();
+        VmStatsVO vmStatsVO = new VmStatsVO(statsForCurrentIteration.getVmId(), msId, timestamp, gsonInner.toJson(vmStats));
         LOGGER.trace(String.format("Recording VM stats: [%s].", vmStatsVO.toString()));
         vmStatsDao.persist(vmStatsVO);
     }

--- a/server/src/main/java/com/cloud/server/VmStatsEntryBaseJsonSerializer.java
+++ b/server/src/main/java/com/cloud/server/VmStatsEntryBaseJsonSerializer.java
@@ -1,0 +1,34 @@
+package com.cloud.server;
+
+import java.lang.reflect.Type;
+
+import com.cloud.agent.api.VmStatsEntryBase;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class VmStatsEntryBaseJsonSerializer implements JsonSerializer{
+
+
+    @Override
+    public JsonElement serialize(Object src, Type typeOfSrc, JsonSerializationContext context) {
+        // TODO Auto-generated method stub
+        VmStatsEntryBase vmobject = (VmStatsEntryBase) src;
+        JsonObject object = new JsonObject();
+        object.add("vmId", context.serialize(vmobject.getVmId()));
+        object.add("cpuUtilization", context.serialize(vmobject.getCPUUtilization()));
+        object.add("networkReadKBs", context.serialize(vmobject.getNetworkReadKBs()));
+        object.add("networkWriteKBs", context.serialize(vmobject.getNetworkWriteKBs()));
+        object.add("diskReadIOs", context.serialize(vmobject.getDiskReadIOs()));
+        object.add("diskWriteIOs", context.serialize(vmobject.getDiskWriteIOs()));
+        object.add("diskReadKBs", context.serialize(vmobject.getDiskReadKBs()));
+        object.add("diskWriteKBs", context.serialize(vmobject.getDiskWriteKBs()));
+        object.add("memoryKBs", context.serialize(vmobject.getMemoryKBs()));
+        object.add("intFreeMemoryKBs", context.serialize(vmobject.getIntFreeMemoryKBs()));
+        object.add("targetMemoryKBs", context.serialize(vmobject.getTargetMemoryKBs()));
+        object.add("numCPUs", context.serialize(vmobject.getNumCPUs()));
+        object.add("entityType", context.serialize(vmobject.getEntityType()));
+        return object;
+   }
+}


### PR DESCRIPTION
## What is the purpose of this PR
This PR fixes the flaky test persistVirtualMachineStatsTestPersistsSuccessfully resulting from https://github.com/mahbubsumon085/cloudstack-flaky-test-resolve/blob/main/server/src/test/java/com/cloud/server/StatsCollectorTest.java
The mentioned tests may fail or pass when it is run as Gson's json creation does not guarantee the order of the variable declaration.

## Why the test fail
The test StatsCollectorTest#persistVirtualMachineStatsTestPersistsSuccessfully fails as the method persistVirtualMachineStats using the toJson() method of Google’s Gson library, in test assuming it will return the JSON string maintaining the variable declaration order, but in reality it does not guarantee the order. Google's Gson library uses Hashmap which does not maintain the order of the json object.

## Reproduce the test failure
Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:
sudo mvn -pl server edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.server.StatsCollectorTest#persistVirtualMachineStatsTestPersistsSuccessfully

## Expected results
The tests should run successfully when run with NonDex.

## Actual Result
We get the following failure for test https://github.com/mahbubsumon085/cloudstack-flaky-test-resolve/blob/main/server/src/test/java/com/cloud/server/StatsCollectorTest #persistVirtualMachineStatsTestPersistsSuccessfully :
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.816 s <<< FAILURE! - in com.cloud.server.StatsCollectorTest
[ERROR] persistVirtualMachineStatsTestPersistsSuccessfully(com.cloud.server.StatsCollectorTest) Time elapsed: 1.807 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[vmId":2,"cpuUtilization":6.0,"networkReadKBs":7.0,"networkWriteKBs":8.0,"diskReadIOs":12.0,"diskWriteIOs":13.0,"diskReadKBs":10.0,"diskWriteKBs":11.0,"memoryKBs":3.0,"intFreeMemoryKBs":4.0,"targetMemoryKBs":5.0,"numCPUs":9,"entityType":"vm"]}> but was:<{"[memoryKBs":3.0,"diskWriteKBs":11.0,"entityType":"vm","diskWriteIOs":13.0,"intFreeMemoryKBs":4.0,"targetMemoryKBs":5.0,"networkWriteKBs":8.0,"diskReadKBs":10.0,"numCPUs":9,"diskReadIOs":12.0,"cpuUtilization":6.0,"vmId":2,"networkReadKBs":7.0]}>
at com.cloud.server.StatsCollectorTest.persistVirtualMachineStatsTestPersistsSuccessfully(StatsCollectorTest.java:303)

## Fix
to pass the flaky test persistVirtualMachineStatsTestPersistsSuccessfully changed the source code implementation  with Gson JsonSerializer interface that confirmed a predefined order while returning from toJson() method.